### PR TITLE
Update Intune_Linux_Custom_Compliance_script.sh

### DIFF
--- a/Linux/Intune_Linux_Custom_Compliance_script.sh
+++ b/Linux/Intune_Linux_Custom_Compliance_script.sh
@@ -571,7 +571,7 @@ PowerShellCommandsString='
 	$hash.Add("MicrosoftDefenderForEndpointOnLinux_DefinitionsStatus_up_to_date", $MicrosoftDefenderForEndpointOnLinux_DefinitionsStatus_up_to_date)
 
 	$logData += "MicrosoftDefenderForEndpointOnLinux_real_time_protection_enabled=$MicrosoftDefenderForEndpointOnLinux_real_time_protection_enabled"
-	$hash.Add("MicrosoftDefenderForEndpointOnLinux_Real_time_protection_enabled", $MicrosoftDefenderForEndpointOnLinux_real_time_protection_enabled)
+	$hash.Add("MicrosoftDefenderForEndpointOnLinux_real_time_protection_enabled", $MicrosoftDefenderForEndpointOnLinux_real_time_protection_enabled)
 
 
 	$logData += "###################################################"


### PR DESCRIPTION
Fixed capitalization in hash add for real time protection. This will cause "Error 65008 (Setting missing in the script result)" in intune.